### PR TITLE
Fix earlier versions' links in make_api_rst.py

### DIFF
--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -66,7 +66,8 @@ current_ltr_minor = int(current_ltr.split(".")[1])
 old_versions_links = ", ".join(reversed(
     [
         f"`3.{v} <https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.{v}/pyqgis-docs-3.{v}.zip>`_"
-        for v in range(0, current_ltr_minor, 2)
+        for v in range(0, current_stable_minor, 2)
+        if v != current_ltr_minor
     ]
 ))
 

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -64,13 +64,15 @@ current_stable = cfg["current_stable"]
 current_ltr = cfg["current_ltr"]
 current_stable_minor = int(current_stable.split(".")[1])
 current_ltr_minor = int(current_ltr.split(".")[1])
-old_versions_links = ", ".join(reversed(
-    [
-        f"`3.{v} <https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.{v}/pyqgis-docs-3.{v}.zip>`_"
-        for v in range(0, current_stable_minor, 2)
-        if v != current_ltr_minor
-    ]
-))
+old_versions_links = ", ".join(
+    reversed(
+        [
+            f"`3.{v} <https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.{v}/pyqgis-docs-3.{v}.zip>`_"
+            for v in range(0, current_stable_minor, 2)
+            if v != current_ltr_minor
+        ]
+    )
+)
 
 py_ext_sig_re = re.compile(
     r"""^(?:([\w.]+::)?([\w.]+\.)?(\w+)\s*(?:\((.*)\)(?:\s*->\s*([\w.]+(?:\[.*?\])?))?(?:\s*\[(signal)\])?)?)?$"""

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -61,13 +61,12 @@ def ltr_tag(v):
 
 current_stable = cfg["current_stable"]
 current_ltr = cfg["current_ltr"]
-current_stable_minor = int(current_stable.split(".")[1]) + 2  # '3.38' => 40
-current_ltr_minor = int(current_ltr.split(".")[1]) + 2  # '3.38' => 40
+current_stable_minor = int(current_stable.split(".")[1])
+current_ltr_minor = int(current_ltr.split(".")[1])
 old_versions_links = ", ".join(reversed(
     [
         f"`3.{v} <https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.{v}/pyqgis-docs-3.{v}.zip>`_"
-        for v in range(0, current_stable_minor, 2)
-        if v not in (current_stable_minor, current_ltr_minor)
+        for v in range(0, current_ltr_minor, 2)
     ]
 ))
 


### PR DESCRIPTION
With current_stable: '3.38' and current_ltr: '3.34':

Earlier versions of the documentation are also available as downloads: [3.36](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.36/pyqgis-docs-3.36.zip), [3.32](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.32/pyqgis-docs-3.32.zip), [3.30](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.30/pyqgis-docs-3.30.zip), [3.28](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.28/pyqgis-docs-3.28.zip), [3.26](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.26/pyqgis-docs-3.26.zip), [3.24](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.24/pyqgis-docs-3.24.zip), [3.22](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.22/pyqgis-docs-3.22.zip), [3.20](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.20/pyqgis-docs-3.20.zip), [3.18](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.18/pyqgis-docs-3.18.zip), [3.16](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.16/pyqgis-docs-3.16.zip), [3.14](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.14/pyqgis-docs-3.14.zip), [3.12](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.12/pyqgis-docs-3.12.zip), [3.10](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.10/pyqgis-docs-3.10.zip), [3.8](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.8/pyqgis-docs-3.8.zip), [3.6](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.6/pyqgis-docs-3.6.zip), [3.4](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.4/pyqgis-docs-3.4.zip), [3.2](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.2/pyqgis-docs-3.2.zip), [3.0](https://github.com/qgis/pyqgis-api-docs-builder/releases/download/3.0/pyqgis-docs-3.0.zip)

Another approach could be to just substitute `Earlier versions of the documentation are also available as downloads:` with `Current and earlier versions of the documentation are also available as downloads:` and list all the available versions.