### PR TITLE
Skip overriden qt methods

### DIFF
--- a/rst/qgis_pydoc_template.txt
+++ b/rst/qgis_pydoc_template.txt
@@ -17,14 +17,18 @@ Class: $CLASS
     .. autoautosummary:: qgis.$PACKAGE.$CLASS
         :enums:
         :nosignatures:
+        :exclude-members: $EXCLUDE_METHODS
 
     .. autoautosummary:: qgis.$PACKAGE.$CLASS
         :methods:
         :nosignatures:
+        :exclude-members: $EXCLUDE_METHODS
 
     .. autoautosummary:: qgis.$PACKAGE.$CLASS
         :signals:
         :nosignatures:
+        :exclude-members: $EXCLUDE_METHODS
 
     .. autoautosummary:: qgis.$PACKAGE.$CLASS
         :attributes:
+        :exclude-members: $EXCLUDE_METHODS

--- a/rst/qgis_pydoc_template.txt
+++ b/rst/qgis_pydoc_template.txt
@@ -12,6 +12,7 @@ Class: $CLASS
    :special-members: __init__
    :members:
    :undoc-members:
+   :exclude-members: $EXCLUDE_METHODS
 
     .. autoautosummary:: qgis.$PACKAGE.$CLASS
         :enums:

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
 from os import makedirs
 from shutil import rmtree
 from string import Template
@@ -70,6 +71,10 @@ old_versions_links = ", ".join(reversed(
         if v not in (current_stable_minor, current_ltr_minor)
     ]
 ))
+
+py_ext_sig_re = re.compile(
+r"""^(?:([\w.]+::)?([\w.]+\.)?(\w+)\s*(?:\((.*)\)(?:\s*->\s*([\w.]+(?:\[.*?\])?))?(?:\s*\[(signal)\])?)?)?$"""
+)
 
 
 # Make sure :numbered: is only specified in the top level index - see
@@ -190,6 +195,10 @@ def generate_docs():
                     continue
 
                 class_doc = getattr(_class, method).__doc__
+
+                if class_doc and all(py_ext_sig_re.match(line) for line in class_doc.split('\n')):
+                    # print(f'docs are function signature only {class_doc}')
+                    class_doc = None
 
                 for base in _class.__bases__:
                     if hasattr(base, method) and (not class_doc or getattr(base, method).__doc__ == class_doc):

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -187,8 +187,7 @@ def generate_docs():
         # Read in the standard rst template we will use for classes
         package_index.write(package_header.replace("PACKAGENAME", package_name))
 
-        for _class in extract_package_classes(package):
-            class_name = _class.__name__
+        for class_name, _class in extract_package_classes(package):
             exclude_methods = set()
             for method in dir(_class):
                 if not hasattr(_class, method):
@@ -196,20 +195,21 @@ def generate_docs():
 
                 class_doc = getattr(_class, method).__doc__
 
-                if class_doc and all(py_ext_sig_re.match(line) for line in class_doc.split('\n')):
+                if class_doc and all(py_ext_sig_re.match(line) for line in str(class_doc).split('\n')):
                     # print(f'docs are function signature only {class_doc}')
                     class_doc = None
 
-                for base in _class.__bases__:
-                    if hasattr(base, method) and (not class_doc or getattr(base, method).__doc__ == class_doc):
-                        # print(f'skipping overridden method with no new doc {method}')
-                        exclude_methods.add(method)
-                        break
-                    elif hasattr(base, method):
-                        # print(f'overrides {method} with different docs')
-                        # print(class_doc)
-                        # print(getattr(base, method).__doc__)
-                        pass
+                if hasattr(_class, '__bases__'):
+                    for base in _class.__bases__:
+                        if hasattr(base, method) and (not class_doc or getattr(base, method).__doc__ == str(class_doc)):
+                            # print(f'skipping overridden method with no new doc {method}')
+                            exclude_methods.add(method)
+                            break
+                        elif hasattr(base, method):
+                            # print(f'overrides {method} with different docs')
+                            # print(class_doc)
+                            # print(getattr(base, method).__doc__)
+                            pass
 
             substitutions = {"PACKAGE": package_name,
                              "CLASS": class_name,
@@ -257,9 +257,9 @@ def extract_package_classes(package):
 
         # if not re.match('^Qgi?s', class_name):
         #     continue
-        classes.append(_class)
+        classes.append((class_name, _class))
 
-    return sorted(classes, key=lambda x: x.__name__)
+    return sorted(classes, key=lambda x: x[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Avoids base PyQt methods showing QObject/QWidget methods for all subclasses, when there's no overrides or docstrings added in the derived PyQGIS class. This avoids cluttering up the class pages with a bunch of low-level methods.

Compare eg current docs for QgsMapLayerComboBox vs after:

![image](https://github.com/user-attachments/assets/ccc5ee38-8cd1-4ab7-8886-5ffe375948dc)

After:

![image](https://github.com/user-attachments/assets/aff9b23c-162a-4b0a-a8ae-821c010b45bc)

Fixes qgis/QGIS#52250