### PR TITLE
Don't show lists of members in the class index pages

### DIFF
--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -143,7 +143,7 @@ PACKAGENAME
 ===================================
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
    :caption: PACKAGENAME:
 
 """


### PR DESCRIPTION
Instead, only show the class names. This reduces the size of eg the "core" index page and makes it easier to find relevant classes