### PR TITLE
Fix appearance of class docstrings, constructor methods, ...

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,3 +1,8 @@
+.graphviz {
+   margin-top: 10px;
+   margin-bottom: 10px;
+}
+
 /* adds scrollbar to sidenav */
 .wy-side-scroll {
    width: auto;

--- a/process_links.py
+++ b/process_links.py
@@ -71,6 +71,20 @@ def process_docstring(app, what, name, obj, options, lines):
                     break
 
             lines[:] = lines[init_idx:]
+            lines_out = []
+            # loop through remaining lines, which are the constructors. Format
+            # these up so they look like proper __init__ method documentation
+            for i, line in enumerate(lines):
+                if re.match(rf"^{class_name}\(", line):
+                    lines_out.append(
+                        re.sub(rf"\b{class_name}\(", ".. py:method:: __init__(", line)
+                    )
+                    lines_out.append("")
+                else:
+                    lines_out.append("    " + line)
+
+            lines[:] = lines_out[:]
+            return
 
     for i in range(len(lines)):
 

--- a/process_links.py
+++ b/process_links.py
@@ -58,7 +58,20 @@ def create_links(doc: str) -> str:
 
 
 def process_docstring(app, what, name, obj, options, lines):
-    # print('d', what, name, obj, options)
+    if what == "class":
+        # hacky approach to detect nested classes, eg QgsCallout.QgsCalloutContext
+        is_nested = len(name.split(".")) > 3
+        if not is_nested:
+            # remove docstring part, we've already included it in the page header
+            # only leave the __init__ methods
+            init_idx = 0
+            class_name = name.split(".")[-1]
+            for init_idx, line in enumerate(lines):
+                if re.match(rf"^{class_name}\(", line):
+                    break
+
+            lines[:] = lines[init_idx:]
+
     for i in range(len(lines)):
 
         # fix seealso

--- a/process_links.py
+++ b/process_links.py
@@ -79,6 +79,7 @@ def process_docstring(app, what, name, obj, options, lines):
                     lines_out.append(
                         re.sub(rf"\b{class_name}\(", ".. py:method:: __init__(", line)
                     )
+                    lines_out.append("    :noindex:")
                     lines_out.append("")
                 else:
                     lines_out.append("    " + line)

--- a/rst/qgis_pydoc_template.txt
+++ b/rst/qgis_pydoc_template.txt
@@ -7,10 +7,10 @@ Class: $CLASS
 
 $HEADER_CONTENT
 
+$TABLE_OF_CONTENTS
+
 .. autoclass:: qgis.$PACKAGE.$CLASS
    :special-members: __init__
    :members:
    :undoc-members:
    :exclude-members: $EXCLUDE_METHODS
-
-   $TABLE_OF_CONTENTS

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -342,12 +342,12 @@ def generate_docs():
 
                 base_header = export_bases(_class)
                 if base_header:
-                    bases_and_subclass_header += "\n" + write_header("Base classes")
+                    bases_and_subclass_header += "\n" + write_header("Base classes", 2)
                     bases_and_subclass_header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
                     bases_and_subclass_header += base_header
 
             if hasattr(_class, "__subclasses__") and _class.__subclasses__():
-                bases_and_subclass_header += "\n" + write_header("Subclasses")
+                bases_and_subclass_header += "\n" + write_header("Subclasses", 2)
                 bases_and_subclass_header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
 
                 for subclass in _class.__subclasses__():
@@ -377,6 +377,7 @@ def generate_docs():
                 if bases_and_subclass_header:
                     if header:
                         header += "\n"
+                    header += write_header("Class Hierarchy")
                     header += inheritance_diagram
                     header += bases_and_subclass_header
                 toc = class_toc

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -376,7 +376,7 @@ def generate_docs():
 
                 if bases_and_subclass_header:
                     if header:
-                        header += "\n"
+                        header += "\n\n"
                     header += write_header("Class Hierarchy")
                     header += inheritance_diagram
                     header += bases_and_subclass_header

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -184,29 +184,29 @@ inheritance_diagram = """
 """
 
 class_toc = """
-    .. autoautosummary:: qgis.$PACKAGE.$CLASS
-        :enums:
-        :nosignatures:
-        :exclude-members: $EXCLUDE_METHODS
+.. autoautosummary:: qgis.$PACKAGE.$CLASS
+    :enums:
+    :nosignatures:
+    :exclude-members: $EXCLUDE_METHODS
 
-    .. autoautosummary:: qgis.$PACKAGE.$CLASS
-        :methods:
-        :nosignatures:
-        :exclude-members: $EXCLUDE_METHODS
+.. autoautosummary:: qgis.$PACKAGE.$CLASS
+    :methods:
+    :nosignatures:
+    :exclude-members: $EXCLUDE_METHODS
 
-    .. autoautosummary:: qgis.$PACKAGE.$CLASS
-        :static_methods:
-        :nosignatures:
-        :exclude-members: $EXCLUDE_METHODS
+.. autoautosummary:: qgis.$PACKAGE.$CLASS
+    :static_methods:
+    :nosignatures:
+    :exclude-members: $EXCLUDE_METHODS
 
-    .. autoautosummary:: qgis.$PACKAGE.$CLASS
-        :signals:
-        :nosignatures:
-        :exclude-members: $EXCLUDE_METHODS
+.. autoautosummary:: qgis.$PACKAGE.$CLASS
+    :signals:
+    :nosignatures:
+    :exclude-members: $EXCLUDE_METHODS
 
-    .. autoautosummary:: qgis.$PACKAGE.$CLASS
-        :attributes:
-        :exclude-members: $EXCLUDE_METHODS
+.. autoautosummary:: qgis.$PACKAGE.$CLASS
+    :attributes:
+    :exclude-members: $EXCLUDE_METHODS
 """
 
 MODULE_TOC_MAX_COLUMN_SIZES = [300, 500]

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -356,6 +356,21 @@ def generate_docs():
                     )
 
             if inspect.isclass(_class):
+                class_doc = _class.__doc__
+                # only keep the actual class doc string part. SIP will
+                # append the constructor signatures and docs at the end
+                # of the class doc, so let's trim those off.
+                # They'll get included later in the actual listing of
+                # class methods
+                lines = class_doc.split("\n")
+                init_idx = 0
+                for init_idx, line in enumerate(lines):
+                    if re.match(rf"^{_class.__name__}\(", line):
+                        break
+
+                doc = "\n".join(lines[:init_idx])
+                _class.__doc__ = doc
+                header = _class.__doc__
                 if bases_and_subclass_header:
                     header += inheritance_diagram
                     header += bases_and_subclass_header

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -362,16 +362,18 @@ def generate_docs():
                 # of the class doc, so let's trim those off.
                 # They'll get included later in the actual listing of
                 # class methods
-                lines = class_doc.split("\n")
-                init_idx = 0
-                for init_idx, line in enumerate(lines):
-                    if re.match(rf"^{_class.__name__}\(", line):
-                        break
+                if class_doc:
+                    lines = class_doc.split("\n")
+                    init_idx = 0
+                    for init_idx, line in enumerate(lines):
+                        if re.match(rf"^{_class.__name__}\(", line):
+                            break
 
-                doc = "\n".join(lines[:init_idx])
-                _class.__doc__ = doc
-                header = _class.__doc__
+                    header = "\n".join(lines[:init_idx])
+
                 if bases_and_subclass_header:
+                    if header:
+                        header += "\n"
                     header += inheritance_diagram
                     header += bases_and_subclass_header
                 toc = class_toc

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -100,7 +100,10 @@ class RecursiveTemplate(Template):
             raise ValueError("Max recursion depth exceeded")
 
         self.depth += 1
-        result = super().safe_substitute(**kws)
+        try:
+            result = super().safe_substitute(**kws)
+        except RecursionError:
+            return self.template
 
         if "$" in result:
             return self.__class__(result)._recursive_substitute(**kws)

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -178,7 +178,7 @@ PACKAGENAME
 
 """
 
-class_header = """
+inheritance_diagram = """
 .. inheritance-diagram:: qgis.$PACKAGE.$CLASS
    :parts: 1
 """
@@ -318,10 +318,7 @@ def generate_docs():
             header = ""
             toc = ""
 
-            if inspect.isclass(_class):
-                header = class_header
-                toc = class_toc
-
+            bases_and_subclass_header = ""
             if hasattr(_class, "__bases__") and _class.__bases__:
 
                 def export_bases(_b):
@@ -342,21 +339,27 @@ def generate_docs():
 
                 base_header = export_bases(_class)
                 if base_header:
-                    header += "\n" + write_header("Base classes")
-                    header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
-                    header += base_header
+                    bases_and_subclass_header += "\n" + write_header("Base classes")
+                    bases_and_subclass_header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
+                    bases_and_subclass_header += base_header
 
             if hasattr(_class, "__subclasses__") and _class.__subclasses__():
-                header += "\n" + write_header("Subclasses")
-                header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
+                bases_and_subclass_header += "\n" + write_header("Subclasses")
+                bases_and_subclass_header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
 
                 for subclass in _class.__subclasses__():
-                    header += make_table_row(
+                    bases_and_subclass_header += make_table_row(
                         [
                             f"`{subclass.__name__} <{subclass.__name__}.html>`_",
                             extract_summary(subclass.__doc__),
                         ]
                     )
+
+            if inspect.isclass(_class):
+                if bases_and_subclass_header:
+                    header += inheritance_diagram
+                    header += bases_and_subclass_header
+                toc = class_toc
 
             for method in dir(_class):
                 if not hasattr(_class, method):


### PR DESCRIPTION
This PR results in a lot of improvements :smile: 

It's directed at fixing this:

![image](https://github.com/user-attachments/assets/6dac5f65-3cdb-40a9-8752-36a5659d56af)

Where:

1. The constructors just get dumped as part of the class description, making the text confusing to read
2. The way the constructors just appear as plain text, not functions


Now:

Class description shows at the top of the page:

![image](https://github.com/user-attachments/assets/d5c73ac2-6913-4a44-9fae-1daadb4f5fa3)

While constructors are nicely documented + formatted before the other methods:

![image](https://github.com/user-attachments/assets/8e9c1ee7-a513-42e8-be02-9ef6e9734f3d)


It also fixes this issue, where the notes block format leaks into the table of contents:

![image](https://github.com/user-attachments/assets/f5ae0df9-d9ef-4979-9443-54829a6224ae)

Now it's correctly formatted:

![image](https://github.com/user-attachments/assets/05be918f-d40c-4faa-8b36-789a598a102e)




