### PR TITLE
Only build sidebar to depth 1

### DIFF
--- a/conf.in.py
+++ b/conf.in.py
@@ -91,6 +91,7 @@ html_theme_options = {
     "titles_only": True,
     "versioning": True,
     "canonical_url": "https://qgis.org/pyqgis/latest",
+    "navigation_depth": 1,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
Only include the module names in the sidebar, which avoids creating a massive sidebar and which messes with in-page search results