### PR TITLE
Skip the global objects from qgsstyle.h

### DIFF
--- a/pyqgis_conf.yml
+++ b/pyqgis_conf.yml
@@ -8,7 +8,36 @@ current_ltr: '3.34'
 skipped:
   - PyProviderMetadata
   - Enum
-
+  - SymbolTable
+  - SymbolId
+  - SymbolName
+  - SymbolXML
+  - SymbolFavoriteId
+  - TagTable
+  - TagId
+  - TagName
+  - TagmapTable
+  - TagmapTagId
+  - TagmapSymbolId
+  - ColorrampTable
+  - ColorrampId
+  - ColorrampName
+  - ColorrampXML
+  - ColorrampFavoriteId
+  - TextFormatTable
+  - TextFormatId
+  - TextFormatName
+  - TextFormatXML
+  - TextFormatFavoriteId
+  - LabelSettingsTable
+  - LabelSettingsId
+  - LabelSettingsName
+  - LabelSettingsXML
+  - LabelSettingsFavoriteId
+  - SmartgroupTable
+  - SmartgroupId
+  - SmartgroupName
+  - SmartgroupXML
 
 non-instantiable:
   - qgis.core.QgsRunProcess


### PR DESCRIPTION
These aren't useful for plugins, and because they are in the global space they clutter up the core class list