### PR TITLE
Link Qt base class objects to Qt c++ doc pages

### DIFF
--- a/conf.in.py
+++ b/conf.in.py
@@ -131,6 +131,7 @@ current_ltr = str(cfg["current_ltr"])
 version_list = ("master", current_stable, current_ltr)
 
 graphviz_output_format = "svg"
+qt_docs_url_base = cfg["qt_docs_url_base"]
 
 url = cfg["pyqgis_url"]
 if not url.endswith("/"):

--- a/inheritance_diagram.py
+++ b/inheritance_diagram.py
@@ -354,6 +354,9 @@ class InheritanceGraph:
             if any(n.endswith(f".{name}") for n in self.class_names):
                 this_node_attrs["fillcolor"] = '"#e7f2fa"'
 
+            if fullname.startswith("PyQt"):
+                this_node_attrs["URL"] = f'"{env.config.qt_docs_url_base}{name.lower()}.html"'
+                this_node_attrs["target"] = '"_top"'
             if fullname in urls:
                 this_node_attrs["URL"] = '"%s"' % urls[fullname]
                 this_node_attrs["target"] = '"_top"'
@@ -550,5 +553,6 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value("inheritance_graph_attrs", {}, "")
     app.add_config_value("inheritance_node_attrs", {}, "")
     app.add_config_value("inheritance_edge_attrs", {}, "")
+    app.add_config_value("qt_docs_url_base", "", "")
     app.add_config_value("inheritance_alias", {}, "")
     return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/pyqgis_conf.yml
+++ b/pyqgis_conf.yml
@@ -4,6 +4,7 @@ pyqgis_url: https://qgis.org/pyqgis
 current_stable: '3.38'
 current_ltr: '3.34'
 
+qt_docs_url_base: https://doc.qt.io/qt-5/
 
 skipped:
   - PyProviderMetadata

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -330,9 +330,15 @@ def generate_docs():
                     for _base in _b.__bases__:
                         if _base.__name__ in ("wrapper", "simplewrapper", "object"):
                             continue
+
+                        if re.match(r"^Q(?!gs)", _base.__name__):
+                            doc_link = f'{cfg["qt_docs_url_base"]}{_base.__name__.lower()}.html'
+                        else:
+                            doc_link = f"{_base.__name__}.html"
+
                         res += make_table_row(
                             [
-                                f"`{_base.__name__} <{_base.__name__}.html>`_",
+                                f"`{_base.__name__} <{doc_link}>`_",
                                 extract_summary(_base.__doc__),
                             ]
                         )


### PR DESCRIPTION
We use the c++ qt docs, because the PyQt docs don't have any real useful detail.

Fixes #175