### PR TITLE
Update conf.in.py

### DIFF
--- a/conf.in.py
+++ b/conf.in.py
@@ -28,7 +28,7 @@ extensions = [
 ]  # , 'rinoh.frontend.sphinx'], 'sphinx_autodoc_typehints'
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The master toctree document.
 master_doc = "index"
@@ -87,7 +87,6 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]  # use with module im
 html_theme_options = {
     "collapse_navigation": False,
     "sticky_navigation": False,
-    "display_version": True,
     "prev_next_buttons_location": None,
     "titles_only": True,
     "versioning": True,

--- a/conf.in.py
+++ b/conf.in.py
@@ -28,7 +28,7 @@ extensions = [
 ]  # , 'rinoh.frontend.sphinx'], 'sphinx_autodoc_typehints'
 
 # The suffix of source filenames.
-source_suffix = {'.rst': 'restructuredtext'}
+source_suffix = {".rst": "restructuredtext"}
 
 # The master toctree document.
 master_doc = "index"

--- a/conf.in.py
+++ b/conf.in.py
@@ -87,6 +87,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]  # use with module im
 html_theme_options = {
     "collapse_navigation": False,
     "sticky_navigation": False,
+    "display_version": True,
     "prev_next_buttons_location": None,
     "titles_only": True,
     "versioning": True,


### PR DESCRIPTION
October 7th, sphinx-rtd-theme released 3.0.0 version which removes the display_version option from the theme (https://github.com/readthedocs/sphinx_rtd_theme/issues/1598). This PR cleans the conf.py file in order to be compatible with their update (and avoid pinging our theme to 2.0.0 given that we are not hosted by them). Afaics, this implies that we'd lose version mention in the top left corner of the pages
![image](https://github.com/user-attachments/assets/1dff5f21-5375-4d65-85ff-d83bc8669ae7)
