### PR TITLE
Raise current_stable to 3.40 to build their docs

### DIFF
--- a/pyqgis_conf.yml
+++ b/pyqgis_conf.yml
@@ -1,7 +1,7 @@
 
 pyqgis_url: https://qgis.org/pyqgis
 
-current_stable: '3.38'
+current_stable: '3.40'
 current_ltr: '3.34'
 
 qt_docs_url_base: https://doc.qt.io/qt-5/


### PR DESCRIPTION
I must confess that I'm not sure if this is still required or whether this value is automagically fed from code repo. @3nids?