### PR TITLE
Provides means to manually trigger docs build using workflow_dispatch

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
@3nids I see the previous workflow_dispatch call in the action was removed (2c084f48401648c08ee1175d911cdb8c73d22878) with no details on why. Is it due to incompatibilities with the new way the process is handled? It could be nice to be able to trigger the build when required.

PS: is that normal that the [docker nightly build](https://hub.docker.com/r/qgis/qgis/tags) is 2 days old?