### PR TITLE
Fix broken links to classes in different modules in TOC

### DIFF
--- a/inheritance_diagram.py
+++ b/inheritance_diagram.py
@@ -72,6 +72,11 @@ module_sig_re = re.compile(
 py_builtins = [obj for obj in vars(builtins).values() if inspect.isclass(obj)]
 py_builtins.extend([sip.wrapper, sip.simplewrapper])
 
+# We have to import ALL PyQGIS modules upfront, so that we can
+# reliably determine class __subclasses__ which fall over different
+# modules
+from qgis import _3d, analysis, core, gui, processing, server  # NOQA
+
 
 def try_import(objname: str) -> Any:
     """Import a object or module using *name* and *currentmodule*.

--- a/scripts/make_api_rst.py
+++ b/scripts/make_api_rst.py
@@ -325,6 +325,12 @@ def generate_docs():
         template_text = template_file.read()
     template = RecursiveTemplate(template_text)
 
+    # first build a master mapping of class name to source package
+    class_packages = {}
+    for package_name, package in packages.items():
+        for class_name, _ in extract_package_classes(package):
+            class_packages[class_name] = package_name
+
     # Iterate over every class in every package and write out an rst
     # template based on standard rst template
 
@@ -354,12 +360,15 @@ def generate_docs():
 
                         if re.match(r"^Q(?!gs)", _base.__name__):
                             doc_link = f'{cfg["qt_docs_url_base"]}{_base.__name__.lower()}.html'
+                            doc_link_cell = f"`{_base.__name__} <{doc_link}>`_"
                         else:
-                            doc_link = f"{_base.__name__}.html"
+                            if _base.__name__ not in class_packages:
+                                continue
+                            doc_link_cell = f":py:class:`{_base.__name__} <qgis.{class_packages[_base.__name__]}.{_base.__name__}>`"
 
                         res += make_table_row(
                             [
-                                f"`{_base.__name__} <{doc_link}>`_",
+                                doc_link_cell,
                                 extract_summary(_base.__doc__),
                             ]
                         )
@@ -378,9 +387,12 @@ def generate_docs():
                 bases_and_subclass_header += f"\n+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[0]}+{'-' * MODULE_TOC_MAX_COLUMN_SIZES[1]}+\n"
 
                 for subclass in _class.__subclasses__():
+                    if subclass.__name__ not in class_packages:
+                        continue
+
                     bases_and_subclass_header += make_table_row(
                         [
-                            f"`{subclass.__name__} <{subclass.__name__}.html>`_",
+                            f":py:class:`{subclass.__name__} <qgis.{class_packages[subclass.__name__]}.{subclass.__name__}>`",
                             extract_summary(subclass.__doc__),
                         ]
                     )


### PR DESCRIPTION
Fixes https://github.com/qgis/pyqgis-api-docs-builder/issues/172

See eg https://qgis.org/pyqgis/master/core/QgsAbstractGeometryTransformer.html#qgis.core.QgsAbstractGeometryTransformer.transformPoint, where the link to QgsGcpGeometryTransformer derived class list is broken (and this derived class is also missing from the inheritance diagram)